### PR TITLE
Fix msExchHideFromAddressLists Update

### DIFF
--- a/Microsoft Active Directory.ps1
+++ b/Microsoft Active Directory.ps1
@@ -1544,6 +1544,12 @@ function Set-ADObject-ADSI {
                 }
                 break
             }
+            
+            'msExchHideFromAddressLists' {
+                # Force Boolean type
+                $dirent.Properties[$p].Value = [System.Boolean]::Parse($Properties[$p])
+                break
+            }
 
             'PasswordNeverExpires' {
                 # Do this after possible 'userAccountControl' is processed


### PR DESCRIPTION
This fixes the periodic error from AD 'The Directory Service is unwilling to process this request' when updating the msExchHideFromAddressLists attribute.